### PR TITLE
upgrade to neo 2.0.1 breaks build, missing lib directive.

### DIFF
--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -272,9 +272,11 @@ namespace Neo.Shell
                 "\tshow gas\n" +
                 "\tclaim gas\n" +
                 "\tcreate address [n=1]\n" +
-                "\timport key <wif|path>\n" +
-                "\texport key [address] [path]\n" +
-                "\tsend <id|alias> <address> <value> [fee=0]\n" +
+				"\timport blocks [path]\n" +
+				"\timport key <wif|path>\n" +
+				"\texport blocks [path]\n" +
+				"\texport key [address] [path]\n" +
+				"\tsend <id|alias> <address> <value> [fee=0]\n" +
                 "Node Commands:\n" +
                 "\tshow state\n" +
                 "\tshow node\n" +

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -271,11 +271,11 @@ namespace Neo.Shell
                 "\tlist key\n" +
                 "\tshow gas\n" +
                 "\tclaim gas\n" +
-                "\tcreate address [n=1]\n" +
-				"\timport blocks [path]\n" +
-				"\timport key <wif|path>\n" +
-				"\texport blocks [path]\n" +
-				"\texport key [address] [path]\n" +
+				"\tcreate address [n=1]\n" +
+                "\timport blocks [path]\n" +
+                "\timport key <wif|path>\n" +
+                "\texport blocks [path]\n" +
+                "\texport key [address] [path]\n" +
 				"\tsend <id|alias> <address> <value> [fee=0]\n" +
                 "Node Commands:\n" +
                 "\tshow state\n" +

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -271,12 +271,12 @@ namespace Neo.Shell
                 "\tlist key\n" +
                 "\tshow gas\n" +
                 "\tclaim gas\n" +
-				"\tcreate address [n=1]\n" +
+                "\tcreate address [n=1]\n" +
                 "\timport blocks [path]\n" +
                 "\timport key <wif|path>\n" +
                 "\texport blocks [path]\n" +
                 "\texport key [address] [path]\n" +
-				"\tsend <id|alias> <address> <value> [fee=0]\n" +
+                "\tsend <id|alias> <address> <value> [fee=0]\n" +
                 "Node Commands:\n" +
                 "\tshow state\n" +
                 "\tshow node\n" +

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -31,7 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Neo" Version="2.0.1" />
+    <PackageReference Include="Neo" Version="2.0.0" />
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.2.0" />
   </ItemGroup>
 
 </Project>

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Neo.CLI</AssemblyTitle>
     <Version>2.0.1</Version>
     <Authors>The Neo Project</Authors>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.6</TargetFramework>
     <AssemblyName>neo-cli</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Neo.CLI</PackageId>
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Neo" Version="2.0.0" />
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.2.0" />
+    <PackageReference Include="Neo" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -30,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.2.0" />
     <PackageReference Include="Neo" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
neo 2.0.1 does not have a netstandard1.6 lib on nuget, only a net461 lib, this causes the build to fail claiming an incompatibility between libraries.

The CLI prompt was still "ant"

The CLI allows importing and exporting of blocks, but the help text doesn't say the ability exists.

I apologize if I did something the wrong way, this is my first github pull request.