### PR TITLE
added unconnectedPeers and badPeers to OnShowNodeCommand

### DIFF
--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -14,6 +14,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Security;
 using System.Threading.Tasks;
+using System.Net;
 
 namespace Neo.Shell
 {
@@ -616,9 +617,21 @@ namespace Neo.Shell
             RemoteNode[] nodes = LocalNode.GetRemoteNodes();
             for (int i = 0; i < nodes.Length; i++)
             {
-                Console.WriteLine($"{nodes[i].RemoteEndpoint.Address} port:{nodes[i].RemoteEndpoint.Port} listen:{nodes[i].ListenerEndpoint?.Port ?? 0} [{i + 1}/{nodes.Length}]");
+                Console.WriteLine($"Remote {nodes[i].RemoteEndpoint.Address} port:{nodes[i].RemoteEndpoint.Port} listen:{nodes[i].ListenerEndpoint?.Port ?? 0} [{i + 1}/{nodes.Length}]");
             }
-            return true;
+			IPEndPoint[] unconnectedPeers = LocalNode.GetUnconnectedPeers();
+			for (int i = 0; i < unconnectedPeers.Length; i++)
+			{
+				Console.WriteLine($"Unconnected {unconnectedPeers[i].Address} port:{unconnectedPeers[i].Port} [{i + 1}/{unconnectedPeers.Length}]");
+			}
+
+			IPEndPoint[] badPeers = LocalNode.GetBadPeers();
+            for (int i = 0; i < badPeers.Length; i++)
+            {
+                Console.WriteLine($"Bad {badPeers[i].Address} port:{badPeers[i].Port} [{i + 1}/{badPeers.Length}]");
+            }
+
+			return true;
         }
 
         private bool OnShowPoolCommand(string[] args)

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -272,9 +272,11 @@ namespace Neo.Shell
                 "\tshow gas\n" +
                 "\tclaim gas\n" +
                 "\tcreate address [n=1]\n" +
-                "\timport key <wif|path>\n" +
-                "\texport key [address] [path]\n" +
-                "\tsend <id|alias> <address> <value> [fee=0]\n" +
+				"\timport blocks [path]\n" +
+				"\timport key <wif|path>\n" +
+				"\texport blocks [path]\n" +
+				"\texport key [address] [path]\n" +
+				"\tsend <id|alias> <address> <value> [fee=0]\n" +
                 "Node Commands:\n" +
                 "\tshow state\n" +
                 "\tshow node\n" +

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -271,11 +271,11 @@ namespace Neo.Shell
                 "\tlist key\n" +
                 "\tshow gas\n" +
                 "\tclaim gas\n" +
-                "\tcreate address [n=1]\n" +
-				"\timport blocks [path]\n" +
-				"\timport key <wif|path>\n" +
-				"\texport blocks [path]\n" +
-				"\texport key [address] [path]\n" +
+				"\tcreate address [n=1]\n" +
+                "\timport blocks [path]\n" +
+                "\timport key <wif|path>\n" +
+                "\texport blocks [path]\n" +
+                "\texport key [address] [path]\n" +
 				"\tsend <id|alias> <address> <value> [fee=0]\n" +
                 "Node Commands:\n" +
                 "\tshow state\n" +

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -273,7 +273,6 @@ namespace Neo.Shell
                 "\tshow gas\n" +
                 "\tclaim gas\n" +
                 "\tcreate address [n=1]\n" +
-                "\timport blocks [path]\n" +
                 "\timport key <wif|path>\n" +
                 "\texport blocks [path]\n" +
                 "\texport key [address] [path]\n" +

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -1,6 +1,7 @@
 ﻿using Neo.Consensus;
 using Neo.Core;
 using Neo.Implementations.Blockchains.LevelDB;
+using Neo.Implementations.Blockchains.Utilities;
 using Neo.Implementations.Wallets.EntityFramework;
 using Neo.IO;
 using Neo.Network;
@@ -29,7 +30,7 @@ namespace Neo.Shell
 
         private void ImportBlocks(Stream stream)
         {
-            LevelDBBlockchain blockchain = (LevelDBBlockchain)Blockchain.Default;
+            Blockchain blockchain = Blockchain.Default;
             blockchain.VerifyBlocks = false;
             using (BinaryReader r = new BinaryReader(stream))
             {
@@ -650,7 +651,7 @@ namespace Neo.Shell
 
         protected internal override void OnStart(string[] args)
         {
-            Blockchain.RegisterBlockchain(new LevelDBBlockchain(Settings.Default.DataDirectoryPath));
+            Blockchain.RegisterBlockchain(new AbstractBlockchain(Settings.Default.DataDirectoryPath, new EntityFactory()));
             LocalNode = new LocalNode();
             Task.Run(() =>
             {

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -271,12 +271,12 @@ namespace Neo.Shell
                 "\tlist key\n" +
                 "\tshow gas\n" +
                 "\tclaim gas\n" +
-				"\tcreate address [n=1]\n" +
+                "\tcreate address [n=1]\n" +
                 "\timport blocks [path]\n" +
                 "\timport key <wif|path>\n" +
                 "\texport blocks [path]\n" +
                 "\texport key [address] [path]\n" +
-				"\tsend <id|alias> <address> <value> [fee=0]\n" +
+                "\tsend <id|alias> <address> <value> [fee=0]\n" +
                 "Node Commands:\n" +
                 "\tshow state\n" +
                 "\tshow node\n" +

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Neo.CLI</AssemblyTitle>
     <Version>2.0.1</Version>
     <Authors>The Neo Project</Authors>
-    <TargetFramework>netcoreapp1.6</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>neo-cli</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Neo.CLI</PackageId>
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.2.0" />
-    <PackageReference Include="Neo" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+    <PackageReference Include="Neo" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -31,7 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Neo" Version="2.0.1" />
+    <PackageReference Include="Neo" Version="2.0.0" />
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.2.0" />
   </ItemGroup>
 
 </Project>

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Neo.CLI</AssemblyTitle>
     <Version>2.0.1</Version>
     <Authors>The Neo Project</Authors>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.6</TargetFramework>
     <AssemblyName>neo-cli</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Neo.CLI</PackageId>
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Neo" Version="2.0.0" />
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.2.0" />
+    <PackageReference Include="Neo" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -30,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="4.2.0" />
     <PackageReference Include="Neo" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
updated to netcoreapp1.1 as the City of Zion unit tests are based on netcoreapp1.1 , so this allows the nuget packages to be used by their neo-cli.

added unconnectedPeers and badPeers to OnShowNodeCommand.

This is useful for debugging the NEO network. For example there was a problem seeing china from chicago, usa on July 31st. I saw the unconnectedPeers node count drop from ~250 to ~70.