### PR TITLE
GetAddressBalance rpc call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,10 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+*.ldb
+neo-cli/Chain/CURRENT
+neo-cli/Chain/LOCK
+neo-cli/Chain/MANIFEST-038636
+neo-cli/Chain/LOG
+neo-cli/libleveldb.dll
+neo-cli/Chain/LOG.old

--- a/.gitignore
+++ b/.gitignore
@@ -287,9 +287,4 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 *.ldb
-neo-cli/Chain/CURRENT
-neo-cli/Chain/LOCK
-neo-cli/Chain/MANIFEST-038636
-neo-cli/Chain/LOG
-neo-cli/libleveldb.dll
-neo-cli/Chain/LOG.old
+neo-cli/Chain/*

--- a/.gitignore
+++ b/.gitignore
@@ -286,5 +286,3 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
-*.ldb
-neo-cli/Chain/*


### PR DESCRIPTION
Added an rpc call in the neo-cli rpc to get balances of all assets grouped in 'confirmed', 'unconfirmed' and 'spendable'.

This makes it easier to see incomming transactions on an address and helps brokers and exchanges who receive coins on an address.