### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Install [.NET Core](https://www.microsoft.com/net/download/core).
 On Linux, install the LevelDB and SQLite3 dev packages. E.g. on Ubuntu:
 
 ```sh
-sudo apt-get install libleveldb-dev sqlite3 libsqlite3-dev
+sudo apt-get install libleveldb-dev sqlite3 libsqlite3-dev libunwind8-dev
+
 ```
 
 On Windows, use the [Neo version of LevelDB](https://github.com/neo-project/leveldb).


### PR DESCRIPTION
Users need also to have, libunwind8-dev or dotnet restore and such commands will fail with error complaining about it.
Fix is "sudo apt-get install libunwind8-dev".