### PR TITLE
Initial continuous integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - docker build -f ci/Dockerfile -t neo-cli-ci .
+  - docker run neo-cli-ci /opt/ci/run-tests-in-docker.sh

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,30 @@
+FROM microsoft/dotnet:2.0-sdk
+
+# Install dependencies:
+RUN apt-get update && apt-get install -y \
+    libleveldb-dev \
+    sqlite3 \
+    libsqlite3-dev \
+    libunwind8-dev \
+    wget \
+    expect \
+    screen \
+    zip
+
+# APT cleanup to reduce image size
+RUN rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+
+# Get code to test
+ADD neo-cli /opt/neo-cli-github
+ADD ci /opt/ci
+
+WORKDIR /opt/neo-cli-github
+
+# Build the project
+RUN dotnet restore
+RUN dotnet publish -c Release
+RUN mv bin/Release/netcoreapp2.0/publish /opt/neo-cli
+
+WORKDIR /opt

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,14 @@
+This are files for the continuous integration with Travis CI.
+
+On each code push, the following tasks are executed:
+
+* Build the latest code
+* Verify the basic neo-cli functionality using [expect](https://linux.die.net/man/1/expect)
+* Verify JSON-RPC functionality with curl
+
+The CI integration consists of the following parts:
+
+* `Dockerfile`: the system to build neo-cli and to run the tests
+* `build-and-test.sh`: this builds the Docker image, starts it and runs the tests inside. This is useful for testing the CI run on a local dev machine.
+* `run-tests-in-docker.sh`: is run inside the Docker container and executes the tests
+* `test-neo-cli.expect`: [expect](https://linux.die.net/man/1/expect) script which verifies neo-cli functionality

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,4 +1,4 @@
-This are files for the continuous integration with Travis CI.
+These are files for the continuous integration with Travis CI.
 
 On each code push, the following tasks are executed:
 

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -2,7 +2,7 @@
 #
 # This script builds neo-cli with dotnet 2.0, and runs the tests.
 #
-CONTAINER_NAME="neo-cli-build"
+CONTAINER_NAME="neo-cli-ci"
 
 # Get absolute path of code and ci folder. This allows to run this script from
 # anywhere, whether from inside this directory or outside.

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# This script builds neo-cli with dotnet 2.0, and runs the tests.
+#
+CONTAINER_NAME="neo-cli-build"
+
+# Get absolute path of code and ci folder. This allows to run this script from
+# anywhere, whether from inside this directory or outside.
+DIR_CI="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+# echo "CI directory: $DIR_CI"
+# echo "Base directory: $DIR_BASE"
+
+# Build the Docker image (includes building the current neo-cli code)
+# docker build --no-cache -f $DIR_CI/Dockerfile -t $CONTAINER_NAME $DIR_BASE
+docker build -f $DIR_CI/Dockerfile -t $CONTAINER_NAME $DIR_BASE
+
+# Stop already running containers
+CONTAINER=$(docker ps -aqf name=$CONTAINER_NAME)
+if [ -n "$CONTAINER" ]; then
+	echo "Stopping container named $CONTAINER_NAME"
+	docker stop $CONTAINER_NAME 1>/dev/null
+	echo "Removing container named $CONTAINER_NAME"
+	docker rm -f $CONTAINER_NAME 1>/dev/null
+fi
+
+# Start a new test container
+docker run --name $CONTAINER_NAME $CONTAINER_NAME /opt/ci/run-tests-in-docker.sh

--- a/ci/run-tests-in-docker.sh
+++ b/ci/run-tests-in-docker.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script is run inside the Docker container and tests neo-cli
+#
+set -e
+
+cd /opt/neo-cli
+
+# Run tests with expect
+expect /opt/ci/test-neo-cli.expect
+
+# Start neo-cli in background for additional JSON-RPC tests
+screen -dmS node1 bash -c "dotnet neo-cli.dll --rpc"
+
+# Wait a little bit
+sleep 3
+
+# Test a RPX smart contract query
+JSONRPC_RES=$( curl --silent \
+  --request POST \
+  --url localhost:10332/ \
+  --header 'accept: application/json' \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "method": "invokefunction",
+    "params": [
+        "ecc6b20d3ccac1ee9ef109af5a7cdb85706b1df9",
+        "totalSupply"
+    ],
+    "id": 3
+  }' )
+
+echo "JSON-RPC response: $JSONRPC_RES"
+
+# Make sure we get a valid response
+echo ${JSONRPC_RES} | grep --quiet "00c10b746f74616c537570706c7967f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec"
+
+# Make sure the response doesn't include "error"
+if echo ${JSONRPC_RES} | grep --quiet "\"error\""; then
+    echo "Error: \"error\" found in json-rpc response"
+    exit 1
+fi

--- a/ci/test-neo-cli.expect
+++ b/ci/test-neo-cli.expect
@@ -1,0 +1,68 @@
+#!/usr/bin/expect -f
+#
+# This script uses expect to test neo-cli
+#
+set timeout 2
+
+# Start neo-cli
+spawn dotnet neo-cli.dll --rpc
+
+# Expect the main input prompt
+expect {
+    "neo> " { }
+    "error" { exit 2 }
+    timeout { exit 1 }
+}
+
+#
+# Test 'create wallet'
+#
+send "create wallet test-wallet.json\n"
+expect {
+    "password:" { send "asd\n" }
+    "error" { exit 2 }
+    timeout { exit 1 }
+}
+
+expect {
+    "password:" { send "asd\n" }
+    "error" { exit 2 }
+    timeout { exit 1 }
+}
+
+# Wallet creation requires a higher timeout
+set timeout 10
+
+expect {
+    "address:" { }
+    "error" { exit 2 }
+    timeout { exit 1 }
+}
+
+# Set timeout back to default
+set timeout 2
+
+#
+# Test 'list address'
+#
+send "list address\n"
+
+expect {
+    -re "A.*" { }
+    "error" { exit 2 }
+    timeout { exit 1 }
+}
+
+#
+# Test 'create address'
+#
+send "create address\n"
+
+expect {
+    "export addresses" { }
+    "neo> " { }
+    "error" { exit 2 }
+    timeout { exit 1 }
+}
+
+exit 0


### PR DESCRIPTION
Proposal of an initial continuous integration setup using [Travis CI](https://travis-ci.org) (see also #72).

If merged and [enabled at Travis CI](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI), code pushes to GitHub will automatically build the code and run a number of tests to verify the neo-cli functionality. 

* The steps executed by Travis CI are defined in `.travis.yml`
* The proposed setup uses a Docker image based on the [microsoft/dotnet:2.0-sdk](https://hub.docker.com/r/microsoft/dotnet/) base image to build the code
* Currently 2 test stages are implemented:
  * **neo-cli tests using [expect](https://linux.die.net/man/1/expect)**: these tests interacts with neo-cli like any normal user, send commands and wait for correct output. This could catch errors like #70. Note: if output of neo-cli commands that are tested with `expect` change, the `test-neo-cli.expect` script will also need to be updated accordingly.
  * **JSON-RPC tests**: neo-cli is started in the background with `dotnet neo-cli.dll --rpc`, and the JSON-RPC api is tested with `curl` commands. Currently one json-rpc test is implemented: querying `totalSupply` of the RPX token. This can catch errors such as #71.

Example output of Travis CI: https://travis-ci.org/metachris/neo-cli/builds/322348356

This PR is an initial CI setup which can easily be extended with more tests in the future.

Looking forward to hearing your thoughts, and whether you are interested in all of those tests or just a part of it, or something completely different. I'd also like to know how you want to name the directory which contains the continuous integration scripts (in this proposal it's simply `/ci`).
