### PR TITLE
Neo cli daemon with wallet unlock

### DIFF
--- a/neo-cli/Program.cs
+++ b/neo-cli/Program.cs
@@ -2,6 +2,7 @@
 using Neo.Wallets;
 using System;
 using System.IO;
+using Newtonsoft.Json;
 
 namespace Neo
 {
@@ -20,6 +21,8 @@ namespace Neo
 
         static void Main(string[] args)
         {
+            Console.WriteLine(JsonConvert.SerializeObject(args, Formatting.Indented));
+            Console.ReadLine();
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             new MainService().Run(args);
         }

--- a/neo-cli/Program.cs
+++ b/neo-cli/Program.cs
@@ -2,13 +2,13 @@
 using Neo.Wallets;
 using System;
 using System.IO;
-using Newtonsoft.Json;
+
 
 namespace Neo
 {
     static class Program
     {
-          internal static Wallet Wallet;
+        internal static Wallet Wallet;
 
         private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
@@ -21,8 +21,6 @@ namespace Neo
 
         static void Main(string[] args)
         {
-            Console.WriteLine(JsonConvert.SerializeObject(args, Formatting.Indented));
-            Console.ReadLine();
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             new MainService().Run(args);
         }

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -790,6 +790,53 @@ namespace Neo.Shell
                                 rpc.Start(Settings.Default.RPC.Port, Settings.Default.RPC.SslCert, Settings.Default.RPC.SslCertPassword);
                             }
                             break;
+                        case "/rpcwallet":
+                        case "--rpcwallet":
+                        case "-rpcw":
+                            if (rpc == null)
+                            {
+                                var path = args[i+1];
+                                var password = args[i + 2];
+                                var checker = false;
+                                if (Path.GetExtension(path) == ".db3")
+                                {
+                                    try
+                                    {
+                                        Program.Wallet = UserWallet.Open(path, password);
+                                        checker = true;
+                                    }
+                                    catch (CryptographicException)
+                                    {
+                                        Console.WriteLine($"failed to open file \"{path}\"");
+                                    }
+                                }
+                                else
+                                {
+                                    NEP6Wallet nep6wallet = new NEP6Wallet(path);
+                                    try
+                                    {
+                                        nep6wallet.Unlock(password);
+                                        Program.Wallet = nep6wallet;
+                                        checker = true;
+                                    }
+                                    catch (CryptographicException)
+                                    {
+                                        Console.WriteLine($"failed to open file \"{path}\"");
+                                    }
+                                    
+                                }
+                                if (checker)
+                                {
+                                    rpc = new RpcServerWithWallet(LocalNode);
+                                    rpc.Start(Settings.Default.RPC.Port, Settings.Default.RPC.SslCert, Settings.Default.RPC.SslCertPassword);
+                                }
+                                else
+                                {
+                                    Console.WriteLine($"rpc with wallet unlock option cannot be started");
+                                }
+                               
+                            }
+                            break;
                         case "-l":
                         case "--log":
                             log = true;


### PR DESCRIPTION
added --rpcwallet option.
this function allow to unlock a wallet before start neo rpc server.

usage:
dotnet neo-cli.dll --rpcwallet "/home/user/walletpath/wallet.db3" "/home/user/passwordfilepath/pass.txt"

dotnet neo-cli.dll --rpcwallet "/home/user/walletpath/wallet.json" "/home/user/passwordfilepath/pass.txt"

or with screen (linux)
screen -dmS neod dotnet neo-cli.dll --rpcwallet "/home/user/walletpath/wallet.db3" "/home/user/passwordfilepath/pass.txt"

screen -dmS neod dotnet neo-cli.dll --rpcwallet "/home/user/walletpath/wallet.json" "/home/user/passwordfilepath/pass.txt"

tiziano@purplesoft.io

Donations are welcome XD
we are developing NEO WEB PANEL MANAGER for NEO NODES (also private deploy of NEO blockchain).

NEO: AYUd4G2dNXAEyUxkZGyMdXAnJ396jJfNDz
ETC: 0x982e45402ad06d0a01f3e54732b28c76d9870422
BTC: 1HxdgF6WsvcRVNiXhz6jZgbD9eopvzAxap
ETH: 0x5cb3784e71710f681410d30d615a3b3bb3c24ff1
