### PR TITLE
Neo cli with daemon unlock config json

### DIFF
--- a/neo-cli/Program.cs
+++ b/neo-cli/Program.cs
@@ -2,6 +2,7 @@
 using Neo.Wallets;
 using System;
 using System.IO;
+using Newtonsoft.Json;
 
 namespace Neo
 {
@@ -20,6 +21,8 @@ namespace Neo
 
         static void Main(string[] args)
         {
+            Console.WriteLine(JsonConvert.SerializeObject(args, Formatting.Indented));
+            Console.ReadLine();
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             new MainService().Run(args);
         }

--- a/neo-cli/Program.cs
+++ b/neo-cli/Program.cs
@@ -3,7 +3,6 @@ using Neo.Wallets;
 using System;
 using System.IO;
 
-
 namespace Neo
 {
     static class Program

--- a/neo-cli/Program.cs
+++ b/neo-cli/Program.cs
@@ -2,13 +2,13 @@
 using Neo.Wallets;
 using System;
 using System.IO;
-using Newtonsoft.Json;
+
 
 namespace Neo
 {
     static class Program
     {
-          internal static Wallet Wallet;
+        internal static Wallet Wallet;
 
         private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
@@ -21,8 +21,6 @@ namespace Neo
 
         static void Main(string[] args)
         {
-            Console.WriteLine(JsonConvert.SerializeObject(args, Formatting.Indented));
-            Console.ReadLine();
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             new MainService().Run(args);
         }

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -10,9 +10,9 @@ namespace Neo
         public PathsSettings Paths { get; }
         public P2PSettings P2P { get; }
         public RPCSettings RPC { get; }
+        public UnlockWalletSettings UnlockWallet { get; set; }
 
         public static Settings Default { get; }
-        public UnlockWalletSettings UnlockWallet { get; set; }
 
         static Settings()
         {
@@ -26,21 +26,6 @@ namespace Neo
             this.P2P = new P2PSettings(section.GetSection("P2P"));
             this.RPC = new RPCSettings(section.GetSection("RPC"));
             this.UnlockWallet = new UnlockWalletSettings(section.GetSection("UnlockWallet"));
-        }
-    }
-
-    public class UnlockWalletSettings
-    {
-
-        public string WalletPath { get; }
-
-        public string WalletPassword { get; }
-        public bool IsActive { get; }
-        public UnlockWalletSettings(IConfigurationSection section)
-        {
-            this.WalletPath = section.GetSection("WalletPath").Value;
-            this.WalletPassword = section.GetSection("WalletPassword").Value;
-            this.IsActive = bool.Parse(section.GetSection("IsActive").Value);
         }
     }
 
@@ -79,6 +64,20 @@ namespace Neo
             this.Port = ushort.Parse(section.GetSection("Port").Value);
             this.SslCert = section.GetSection("SslCert").Value;
             this.SslCertPassword = section.GetSection("SslCertPassword").Value;
+        }
+    }
+
+    public class UnlockWalletSettings
+    {
+        public string Path { get; }
+        public string Password { get; }
+        public bool IsActive { get; }
+
+        public UnlockWalletSettings(IConfigurationSection section)
+        {
+            this.Path = section.GetSection("WalletPath").Value;
+            this.Password = section.GetSection("WalletPassword").Value;
+            this.IsActive = bool.Parse(section.GetSection("IsActive").Value);
         }
     }
 }

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -12,6 +12,7 @@ namespace Neo
         public RPCSettings RPC { get; }
 
         public static Settings Default { get; }
+        public WalletUnlockSettings WalletUnlock { get; set; }
 
         static Settings()
         {
@@ -24,6 +25,21 @@ namespace Neo
             this.Paths = new PathsSettings(section.GetSection("Paths"));
             this.P2P = new P2PSettings(section.GetSection("P2P"));
             this.RPC = new RPCSettings(section.GetSection("RPC"));
+            this.WalletUnlock = new WalletUnlockSettings(section.GetSection("WalletUnlock"));
+        }
+    }
+
+    public class WalletUnlockSettings
+    {
+        public string WalletPath { get; }
+       
+        public string WalletPassword { get; }
+
+        public WalletUnlockSettings(IConfigurationSection section)
+        {
+            this.WalletPath = section.GetSection("WalletPath").Value;
+            this.WalletPassword = section.GetSection("WalletPassword").Value;
+            
         }
     }
 

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -73,9 +73,12 @@ namespace Neo
 
         public UnlockWalletSettings(IConfigurationSection section)
         {
-            this.Path = section.GetSection("WalletPath").Value;
-            this.Password = section.GetSection("WalletPassword").Value;
-            this.IsActive = bool.Parse(section.GetSection("IsActive").Value);
+            if (section.Value != null)
+            {
+                this.Path = section.GetSection("WalletPath").Value;
+                this.Password = section.GetSection("WalletPassword").Value;
+                this.IsActive = bool.Parse(section.GetSection("IsActive").Value);
+            }
         }
     }
 }

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -12,7 +12,7 @@ namespace Neo
         public RPCSettings RPC { get; }
 
         public static Settings Default { get; }
-        public WalletUnlockSettings WalletUnlock { get; set; }
+        public UnlockWalletSettings UnlockWallet { get; set; }
 
         static Settings()
         {
@@ -25,21 +25,22 @@ namespace Neo
             this.Paths = new PathsSettings(section.GetSection("Paths"));
             this.P2P = new P2PSettings(section.GetSection("P2P"));
             this.RPC = new RPCSettings(section.GetSection("RPC"));
-            this.WalletUnlock = new WalletUnlockSettings(section.GetSection("WalletUnlock"));
+            this.UnlockWallet = new UnlockWalletSettings(section.GetSection("UnlockWallet"));
         }
     }
 
-    public class WalletUnlockSettings
+    public class UnlockWalletSettings
     {
-        public string WalletPath { get; }
-       
-        public string WalletPassword { get; }
 
-        public WalletUnlockSettings(IConfigurationSection section)
+        public string WalletPath { get; }
+
+        public string WalletPassword { get; }
+        public bool IsActive { get; }
+        public UnlockWalletSettings(IConfigurationSection section)
         {
             this.WalletPath = section.GetSection("WalletPath").Value;
             this.WalletPassword = section.GetSection("WalletPassword").Value;
-            
+            this.IsActive = bool.Parse(section.GetSection("IsActive").Value);
         }
     }
 

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -795,55 +795,43 @@ namespace Neo.Shell
                         case "-rpcw":
                             if (rpc == null)
                             {
-                                var path = args[i + 1];
-                                var passwordFile = args[i + 2];
-                                if (File.Exists(passwordFile))
+                                var checker = false;
+                                if (Path.GetExtension(Settings.Default.WalletUnlock.WalletPath) == ".db3")
                                 {
+                                    try
+                                    {
+                                        Program.Wallet = UserWallet.Open(Settings.Default.WalletUnlock.WalletPath, Settings.Default.WalletUnlock.WalletPassword);
+                                        checker = true;
+                                    }
+                                    catch (CryptographicException)
+                                    {
+                                        Console.WriteLine($"failed to open file \"{Settings.Default.WalletUnlock.WalletPath}\"");
+                                    }
+                                }
+                                else
+                                {
+                                    NEP6Wallet nep6wallet = new NEP6Wallet(Settings.Default.WalletUnlock.WalletPath);
+                                    try
+                                    {
+                                        nep6wallet.Unlock(Settings.Default.WalletUnlock.WalletPassword);
+                                        Program.Wallet = nep6wallet;
+                                        checker = true;
+                                    }
+                                    catch (CryptographicException)
+                                    {
+                                        Console.WriteLine($"failed to open file \"{Settings.Default.WalletUnlock.WalletPath}\"");
+                                    }
 
-                                    var password = File.ReadAllText(passwordFile);
-                                    var checker = false;
-                                    if (Path.GetExtension(path) == ".db3")
-                                    {
-                                        try
-                                        {
-                                            Program.Wallet = UserWallet.Open(path, password);
-                                            checker = true;
-                                        }
-                                        catch (CryptographicException)
-                                        {
-                                            Console.WriteLine($"failed to open file \"{path}\"");
-                                        }
-                                    }
-                                    else
-                                    {
-                                        NEP6Wallet nep6wallet = new NEP6Wallet(path);
-                                        try
-                                        {
-                                            nep6wallet.Unlock(password);
-                                            Program.Wallet = nep6wallet;
-                                            checker = true;
-                                        }
-                                        catch (CryptographicException)
-                                        {
-                                            Console.WriteLine($"failed to open file \"{path}\"");
-                                        }
-
-                                    }
-                                    if (checker)
-                                    {
-                                        rpc = new RpcServerWithWallet(LocalNode);
-                                        rpc.Start(Settings.Default.RPC.Port, Settings.Default.RPC.SslCert, Settings.Default.RPC.SslCertPassword);
-                                    }
-                                    else
-                                    {
-                                        Console.WriteLine($"rpc with wallet unlock option cannot be started");
-                                    }
+                                }
+                                if (checker)
+                                {
+                                    rpc = new RpcServerWithWallet(LocalNode);
+                                    rpc.Start(Settings.Default.RPC.Port, Settings.Default.RPC.SslCert, Settings.Default.RPC.SslCertPassword);
                                 }
                                 else
                                 {
                                     Console.WriteLine($"rpc with wallet unlock option cannot be started");
                                 }
-
                             }
                             break;
                         case "-l":

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -790,6 +790,53 @@ namespace Neo.Shell
                                 rpc.Start(Settings.Default.RPC.Port, Settings.Default.RPC.SslCert, Settings.Default.RPC.SslCertPassword);
                             }
                             break;
+                        case "/rpcwallet":
+                        case "--rpcwallet":
+                        case "-rpcw":
+                            if (rpc == null)
+                            {
+                                var path = args[i+1];
+                                var password = args[i + 2];
+                                var checker = false;
+                                if (Path.GetExtension(path) == ".db3")
+                                {
+                                    try
+                                    {
+                                        Program.Wallet = UserWallet.Open(path, password);
+                                        checker = true;
+                                    }
+                                    catch (CryptographicException)
+                                    {
+                                        Console.WriteLine($"failed to open file \"{path}\"");
+                                    }
+                                }
+                                else
+                                {
+                                    NEP6Wallet nep6wallet = new NEP6Wallet(path);
+                                    try
+                                    {
+                                        nep6wallet.Unlock(password);
+                                        Program.Wallet = nep6wallet;
+                                        checker = true;
+                                    }
+                                    catch (CryptographicException)
+                                    {
+                                        Console.WriteLine($"failed to open file \"{path}\"");
+                                    }
+                                    
+                                }
+                                if (checker)
+                                {
+                                    rpc = new RpcServerWithWallet(LocalNode);
+                                    rpc.Start(Settings.Default.RPC.Port, Settings.Default.RPC.SslCert, Settings.Default.RPC.SslCertPassword);
+                                }
+                                else
+                                {
+                                    Console.WriteLine($"rpc with wallet unlock option cannot be started");
+                                }
+                               
+                            }
+                            break;
                         case "-l":
                         case "--log":
                             log = true;

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -776,6 +776,36 @@ namespace Neo.Shell
                     File.Delete(acc_zip_path);
                 }
                 LocalNode.Start(Settings.Default.P2P.Port, Settings.Default.P2P.WsPort);
+
+                if (Settings.Default.UnlockWallet.IsActive)
+                {
+                    if (Path.GetExtension(Settings.Default.UnlockWallet.WalletPath) == ".db3")
+                    {
+                        try
+                        {
+                            Program.Wallet = UserWallet.Open(Settings.Default.UnlockWallet.WalletPath, Settings.Default.UnlockWallet.WalletPassword);
+                        }
+                        catch (CryptographicException)
+                        {
+                            Console.WriteLine($"failed to open file \"{Settings.Default.UnlockWallet.WalletPath}\"");
+                        }
+                    }
+                    else
+                    {
+                        NEP6Wallet nep6wallet = new NEP6Wallet(Settings.Default.UnlockWallet.WalletPath);
+                        try
+                        {
+                            nep6wallet.Unlock(Settings.Default.UnlockWallet.WalletPassword);
+                            Program.Wallet = nep6wallet;
+                        }
+                        catch (CryptographicException)
+                        {
+                            Console.WriteLine($"failed to open file \"{Settings.Default.UnlockWallet.WalletPath}\"");
+                        }
+
+                    }
+                }
+
                 bool log = false;
                 for (int i = 0; i < args.Length; i++)
                 {
@@ -788,50 +818,6 @@ namespace Neo.Shell
                             {
                                 rpc = new RpcServerWithWallet(LocalNode);
                                 rpc.Start(Settings.Default.RPC.Port, Settings.Default.RPC.SslCert, Settings.Default.RPC.SslCertPassword);
-                            }
-                            break;
-                        case "/rpcwallet":
-                        case "--rpcwallet":
-                        case "-rpcw":
-                            if (rpc == null)
-                            {
-                                var checker = false;
-                                if (Path.GetExtension(Settings.Default.WalletUnlock.WalletPath) == ".db3")
-                                {
-                                    try
-                                    {
-                                        Program.Wallet = UserWallet.Open(Settings.Default.WalletUnlock.WalletPath, Settings.Default.WalletUnlock.WalletPassword);
-                                        checker = true;
-                                    }
-                                    catch (CryptographicException)
-                                    {
-                                        Console.WriteLine($"failed to open file \"{Settings.Default.WalletUnlock.WalletPath}\"");
-                                    }
-                                }
-                                else
-                                {
-                                    NEP6Wallet nep6wallet = new NEP6Wallet(Settings.Default.WalletUnlock.WalletPath);
-                                    try
-                                    {
-                                        nep6wallet.Unlock(Settings.Default.WalletUnlock.WalletPassword);
-                                        Program.Wallet = nep6wallet;
-                                        checker = true;
-                                    }
-                                    catch (CryptographicException)
-                                    {
-                                        Console.WriteLine($"failed to open file \"{Settings.Default.WalletUnlock.WalletPath}\"");
-                                    }
-
-                                }
-                                if (checker)
-                                {
-                                    rpc = new RpcServerWithWallet(LocalNode);
-                                    rpc.Start(Settings.Default.RPC.Port, Settings.Default.RPC.SslCert, Settings.Default.RPC.SslCertPassword);
-                                }
-                                else
-                                {
-                                    Console.WriteLine($"rpc with wallet unlock option cannot be started");
-                                }
                             }
                             break;
                         case "-l":

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -898,6 +898,17 @@ namespace Neo.Shell
                     }
                 }
                 LocalNode.Start(Settings.Default.P2P.Port, Settings.Default.P2P.WsPort);
+                if (Settings.Default.UnlockWallet.IsActive)
+                {
+                    try
+                    {
+                        Program.Wallet = OpenWallet(Settings.Default.UnlockWallet.Path, Settings.Default.UnlockWallet.Password);
+                    }
+                    catch (CryptographicException)
+                    {
+                        Console.WriteLine($"failed to open file \"{Settings.Default.UnlockWallet.Path}\"");
+                    }
+                }
                 if (useRPC)
                 {
                     rpc = new RpcServerWithWallet(LocalNode);

--- a/neo-cli/config.json
+++ b/neo-cli/config.json
@@ -11,6 +11,10 @@
       "Port": 10332,
       "SslCert": "",
       "SslCertPassword": ""
+    },
+    "WalletUnlock": {
+      "WalletPath": "",
+      "WalletPassword": ""
     }
   }
 }

--- a/neo-cli/config.json
+++ b/neo-cli/config.json
@@ -12,9 +12,10 @@
       "SslCert": "",
       "SslCertPassword": ""
     },
-    "WalletUnlock": {
-      "WalletPath": "",
-      "WalletPassword": ""
+    "UnlockWallet": {
+      "WalletPath": "/home/user/walletpath/wallet.db3",
+      "WalletPassword": "SuP3r53cUr£W@l137P45Sw0rd!23!",
+      "IsActive": false 
     }
   }
 }

--- a/neo-cli/config.json
+++ b/neo-cli/config.json
@@ -13,8 +13,8 @@
       "SslCertPassword": ""
     },
     "UnlockWallet": {
-      "WalletPath": "/home/user/walletpath/wallet.db3",
-      "WalletPassword": "SuP3r53cUr£W@l137P45Sw0rd!23!",
+      "Path": "",
+      "Password": "",
       "IsActive": false 
     }
   }

--- a/neo-cli/config.mainnet.json
+++ b/neo-cli/config.mainnet.json
@@ -13,8 +13,8 @@
       "SslCertPassword": ""
     },
     "UnlockWallet": {
-      "WalletPath": "/home/user/walletpath/wallet.db3",
-      "WalletPassword": "SuP3r53cUr£W@l137P45Sw0rd!23!",
+      "Path": "",
+      "Password": "",
       "IsActive": false
     }
   }

--- a/neo-cli/config.mainnet.json
+++ b/neo-cli/config.mainnet.json
@@ -11,6 +11,11 @@
       "Port": 10332,
       "SslCert": "",
       "SslCertPassword": ""
+    },
+    "UnlockWallet": {
+      "WalletPath": "/home/user/walletpath/wallet.db3",
+      "WalletPassword": "SuP3r53cUr£W@l137P45Sw0rd!23!",
+      "IsActive": false
     }
   }
 }

--- a/neo-cli/config.testnet.json
+++ b/neo-cli/config.testnet.json
@@ -13,8 +13,8 @@
       "SslCertPassword": ""
     },
     "UnlockWallet": {
-      "WalletPath": "/home/user/walletpath/wallet.db3",
-      "WalletPassword": "SuP3r53cUr£W@l137P45Sw0rd!23!",
+      "Path": "",
+      "Password": "",
       "IsActive": false
     }
   }

--- a/neo-cli/config.testnet.json
+++ b/neo-cli/config.testnet.json
@@ -11,6 +11,11 @@
       "Port": 20332,
       "SslCert": "",
       "SslCertPassword": ""
+    },
+    "UnlockWallet": {
+      "WalletPath": "/home/user/walletpath/wallet.db3",
+      "WalletPassword": "SuP3r53cUr£W@l137P45Sw0rd!23!",
+      "IsActive": false
     }
   }
 }

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -21,9 +21,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="config.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Update="config.json;config.mainnet.json;config.testnet.json;protocol.json;protocol.mainnet.json;protocol.testnet.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/neo-cli/neo-cli.csproj
+++ b/neo-cli/neo-cli.csproj
@@ -21,6 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="config.json;config.mainnet.json;config.testnet.json;protocol.json;protocol.mainnet.json;protocol.testnet.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>


### PR DESCRIPTION
added new section in config.json:
 
"UnlockWallet": {
      "WalletPath": "/home/user/walletpath/wallet.db3",
      "WalletPassword": "SuP3r53cUr£W@l137P45Sw0rd!23!",
      "IsActive": false 
    }

This will allow the cli to unlock a specified wallet before start all other things.
The feature can be activated and deactivated setting IsActive property properly, with true or false.

usage:
dotnet neo-cli.dll

with screen:
screen -dmS neod dotnet neo-cli.dll

Enjoy it.

tiziano@purplesoft.io