### PR TITLE
Neo cli start consensus config json

### DIFF
--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -69,6 +69,7 @@ namespace Neo
     {
         public string Path { get; }
         public string Password { get; }
+        public bool StartConsensus { get; }
         public bool IsActive { get; }
 
         public UnlockWalletSettings(IConfigurationSection section)
@@ -77,6 +78,7 @@ namespace Neo
             {
                 this.Path = section.GetSection("WalletPath").Value;
                 this.Password = section.GetSection("WalletPassword").Value;
+                this.StartConsensus = bool.Parse(section.GetSection("StartConsensus").Value);
                 this.IsActive = bool.Parse(section.GetSection("IsActive").Value);
             }
         }

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -908,7 +908,7 @@ namespace Neo.Shell
                     {
                         Console.WriteLine($"failed to open file \"{Settings.Default.UnlockWallet.Path}\"");
                     }
-                    if (Settings.Default.UnlockWallet.StartConsensus)
+                    if (Settings.Default.UnlockWallet.StartConsensus && Program.Wallet != null)
                     {
                         OnStartConsensusCommand(null);
                     }

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -908,6 +908,10 @@ namespace Neo.Shell
                     {
                         Console.WriteLine($"failed to open file \"{Settings.Default.UnlockWallet.Path}\"");
                     }
+                    if (Settings.Default.UnlockWallet.StartConsensus)
+                    {
+                        OnStartConsensusCommand(null);
+                    }
                 }
                 if (useRPC)
                 {

--- a/neo-cli/config.json
+++ b/neo-cli/config.json
@@ -16,7 +16,8 @@
     "UnlockWallet": {
       "Path": "",
       "Password": "",
-      "IsActive": false 
+      "StartConsensus": false,
+      "IsActive": false
     }
   }
 }

--- a/neo-cli/config.mainnet.json
+++ b/neo-cli/config.mainnet.json
@@ -16,6 +16,7 @@
     "UnlockWallet": {
       "Path": "",
       "Password": "",
+      "StartConsensus": false,
       "IsActive": false
     }
   }

--- a/neo-cli/config.testnet.json
+++ b/neo-cli/config.testnet.json
@@ -16,6 +16,7 @@
     "UnlockWallet": {
       "Path": "",
       "Password": "",
+      "StartConsensus": false,
       "IsActive": false
     }
   }


### PR DESCRIPTION
start consensus at startup.
enable/disable the feature from config.json - UnlockWallet Section.
I love it for development purpose... is very useful.
Enjoy it,
tiziano@purplesoft.io