### PR TITLE
settings.cs fix

### DIFF
--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -74,7 +74,8 @@ namespace Neo
 
         public UnlockWalletSettings(IConfigurationSection section)
         {
-            if (section.Exists()) {
+            if (section.Exists()) 
+            {
                 this.Path = section.GetSection("Path").Value;
                 this.Password = section.GetSection("Password").Value;
                 this.StartConsensus = bool.Parse(section.GetSection("StartConsensus").Value);

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -74,13 +74,10 @@ namespace Neo
 
         public UnlockWalletSettings(IConfigurationSection section)
         {
-            if (section.Value != null)
-            {
-                this.Path = section.GetSection("WalletPath").Value;
-                this.Password = section.GetSection("WalletPassword").Value;
-                this.StartConsensus = bool.Parse(section.GetSection("StartConsensus").Value);
-                this.IsActive = bool.Parse(section.GetSection("IsActive").Value);
-            }
+            this.Path = section.GetSection("Path").Value;
+            this.Password = section.GetSection("Password").Value;
+            this.StartConsensus = bool.Parse(section.GetSection("StartConsensus").Value);
+            this.IsActive = bool.Parse(section.GetSection("IsActive").Value); 
         }
     }
 }

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -74,10 +74,13 @@ namespace Neo
 
         public UnlockWalletSettings(IConfigurationSection section)
         {
-            this.Path = section.GetSection("Path").Value;
-            this.Password = section.GetSection("Password").Value;
-            this.StartConsensus = bool.Parse(section.GetSection("StartConsensus").Value);
-            this.IsActive = bool.Parse(section.GetSection("IsActive").Value); 
+            if (section.Exists()) {
+                this.Path = section.GetSection("Path").Value;
+                this.Password = section.GetSection("Password").Value;
+                this.StartConsensus = bool.Parse(section.GetSection("StartConsensus").Value);
+                this.IsActive = bool.Parse(section.GetSection("IsActive").Value);     
+            }
+            
         }
     }
 }

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -74,14 +74,13 @@ namespace Neo
 
         public UnlockWalletSettings(IConfigurationSection section)
         {
-            if (section.Exists()) 
+            if (section.Exists())
             {
                 this.Path = section.GetSection("Path").Value;
                 this.Password = section.GetSection("Password").Value;
                 this.StartConsensus = bool.Parse(section.GetSection("StartConsensus").Value);
                 this.IsActive = bool.Parse(section.GetSection("IsActive").Value);     
             }
-            
         }
     }
 }


### PR DESCRIPTION
This fixes inconsistency between `config.json` and `settings.cs` handling of `unlockWallet` section in `UnlockWalletSettings` method. In particular: `config.json` contains `Path` and `Password` sections but they are referenced as `WalletPath` and `WalletPassword`.
Also removes bad condition  - `section.Value` is always `null` because it doesn't contain any value only nested sections.