### PR TITLE
Add getwalletheight RPC call

### DIFF
--- a/neo-cli/Network/RPC/RpcServerWithWallet.cs
+++ b/neo-cli/Network/RPC/RpcServerWithWallet.cs
@@ -52,10 +52,7 @@ namespace Neo.Network.RPC
                     if (Program.Wallet == null)
                         throw new RpcException(-400, "Access denied.");
                     else
-                    {
-                        uint wh = (Program.Wallet.WalletHeight > 0) ? Program.Wallet.WalletHeight - 1 : 0;
-                        return wh.ToString();
-                    }
+                        return (Program.Wallet.WalletHeight > 0) ? Program.Wallet.WalletHeight - 1 : 0;
                 case "listaddress":
                     if (Program.Wallet == null)
                         throw new RpcException(-400, "Access denied.");

--- a/neo-cli/Network/RPC/RpcServerWithWallet.cs
+++ b/neo-cli/Network/RPC/RpcServerWithWallet.cs
@@ -48,6 +48,14 @@ namespace Neo.Network.RPC
                         }
                         return json;
                     }
+                case "getwalletheight":
+                    if (Program.Wallet == null)
+                        throw new RpcException(-400, "Access denied.");
+                    else
+                    {
+                        uint wh = (Program.Wallet.WalletHeight > 0) ? Program.Wallet.WalletHeight - 1 : 0;
+                        return wh.ToString();
+                    }
                 case "listaddress":
                     if (Program.Wallet == null)
                         throw new RpcException(-400, "Access denied.");


### PR DESCRIPTION
This adds a RPC call to retrieve the wallet height. This helps with understanding if the wallet has caught up to the block height.

It returns 400 Access denied if a wallet is not loaded in the same way as other RPC calls.