### PR TITLE
Minnor plugin for stop loading on a defined height

### DIFF
--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -5,6 +5,7 @@ using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.Persistence.LevelDB;
+using Neo.Plugins;
 using Neo.Services;
 using Neo.SmartContract;
 using Neo.Wallets;
@@ -42,6 +43,10 @@ namespace Neo.Shell
                 uint start = read_start ? r.ReadUInt32() : 0;
                 uint count = r.ReadUInt32();
                 uint end = start + count - 1;
+
+                foreach (ILoadingPlugin plugin in Plugin.LoadingPlugins)
+			plugin.UpdateMaxHeight(ref end);
+
                 if (end <= Blockchain.Singleton.Height) yield break;
                 for (uint height = start; height <= end; height++)
                 {


### PR DESCRIPTION
Hey, Erik,

We are creating some snapshot tools for reading the storage of any desired block.
This plugin will help us to design it in a better manner.

However, we am still getting this error:
```cs
Shell/MainService.cs(47,57): error CS0117: 'Plugin' does not contain a definition for 'LoadingPlugins' [/opt/neo-cli/neo-cli/neo-cli.csproj]
```
It also happen when we try to include any other one.
```cs
Shell/MainService.cs(47,57): error CS0117: 'Plugin' does not contain a definition for 'Policies' [/opt/neo-cli/neo-cli/neo-cli.csproj]

```
In fact, this is the first Plugin on the neo-cli itself, thus, maybe something is missing.