### PR TITLE
Modify claim operation to 50 claims per tx

### DIFF
--- a/neo-cli/Shell/Coins.cs
+++ b/neo-cli/Shell/Coins.cs
@@ -5,6 +5,7 @@ using Neo.Persistence;
 using Neo.SmartContract;
 using Neo.Wallets;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Neo.Shell
@@ -102,7 +103,7 @@ namespace Neo.Shell
             using (Snapshot snapshot = Blockchain.Singleton.GetSnapshot())
             {
                 int claim_count = (claims.Length - 1) / MAX_CLAIMS_AMOUNT + 1;
-                ClaimTransaction[] txs = new ClaimTransaction[claim_count];
+                List<ClaimTransaction> txs = new List<ClaimTransaction>();
                 if (claim_count > 1)
                 {
                     Console.WriteLine($"total claims: {claims.Length}, processing(0/{claim_count})...");
@@ -128,10 +129,13 @@ namespace Neo.Shell
                             }
                         }
                     };
-                    txs.SetValue((ClaimTransaction)SignTransaction(tx), i);
+                    if ((tx = (ClaimTransaction)SignTransaction(tx)) != null)
+                    {
+                        txs.Append(tx);
+                    }
                 }
 
-                return txs;
+                return txs.ToArray();
             }
         }
 

--- a/neo-cli/Shell/Coins.cs
+++ b/neo-cli/Shell/Coins.cs
@@ -67,7 +67,7 @@ namespace Neo.Shell
             {
                 ClaimTransaction tx = new ClaimTransaction
                 {
-                    Claims = claims,
+                    Claims = claims.Take(MAX_CLAIMS_AMOUNT).ToArray(),
                     Attributes = new TransactionAttribute[0],
                     Inputs = new CoinReference[0],
                     Outputs = new[]
@@ -75,7 +75,7 @@ namespace Neo.Shell
                         new TransactionOutput
                         {
                             AssetId = Blockchain.UtilityToken.Hash,
-                            Value = snapshot.CalculateBonus(claims),
+                            Value = snapshot.CalculateBonus(claims.Take(MAX_CLAIMS_AMOUNT)),
                             ScriptHash = current_wallet.GetChangeAddress()
                         }
                     }

--- a/neo-cli/Shell/Coins.cs
+++ b/neo-cli/Shell/Coins.cs
@@ -101,7 +101,7 @@ namespace Neo.Shell
 
             using (Snapshot snapshot = Blockchain.Singleton.GetSnapshot())
             {
-                int claim_count = claims.Length / MAX_CLAIMS_AMOUNT + 1;
+                int claim_count = (claims.Length - 1) / MAX_CLAIMS_AMOUNT + 1;
                 ClaimTransaction[] txs = new ClaimTransaction[claim_count];
                 if (claim_count > 1)
                 {

--- a/neo-cli/Shell/Coins.cs
+++ b/neo-cli/Shell/Coins.cs
@@ -51,8 +51,43 @@ namespace Neo.Shell
             }
         }
 
+        public ClaimTransaction Claim()
+        {
 
-        public ClaimTransaction[] Claim()
+            if (this.AvailableBonus() == Fixed8.Zero)
+            {
+                Console.WriteLine($"no gas to claim");
+                return null;
+            }
+
+            CoinReference[] claims = current_wallet.GetUnclaimedCoins().Select(p => p.Reference).ToArray();
+            if (claims.Length == 0) return null;
+
+            using (Snapshot snapshot = Blockchain.Singleton.GetSnapshot())
+            {
+                ClaimTransaction tx = new ClaimTransaction
+                {
+                    Claims = claims,
+                    Attributes = new TransactionAttribute[0],
+                    Inputs = new CoinReference[0],
+                    Outputs = new[]
+                    {
+                        new TransactionOutput
+                        {
+                            AssetId = Blockchain.UtilityToken.Hash,
+                            Value = snapshot.CalculateBonus(claims),
+                            ScriptHash = current_wallet.GetChangeAddress()
+                        }
+                    }
+
+                };
+
+                return (ClaimTransaction)SignTransaction(tx);
+            }
+        }
+
+
+        public ClaimTransaction[] ClaimAll()
         {
 
             if (this.AvailableBonus() == Fixed8.Zero)

--- a/neo-cli/Shell/Coins.cs
+++ b/neo-cli/Shell/Coins.cs
@@ -129,9 +129,14 @@ namespace Neo.Shell
                             }
                         }
                     };
+
                     if ((tx = (ClaimTransaction)SignTransaction(tx)) != null)
                     {
-                        txs.Append(tx);
+                        txs.Add(tx);
+                    }
+                    else
+                    {
+                        break;
                     }
                 }
 

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -512,7 +512,7 @@ namespace Neo.Shell
                         {
                             case "all":
                                 ClaimTransaction[] txs = coins.ClaimAll();
-                                if (txs.Length > 0)
+                                if (txs != null && txs.Length > 0)
                                 {
                                     foreach (ClaimTransaction tx in txs)
                                     {

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -506,10 +506,13 @@ namespace Neo.Shell
             switch (args[1].ToLower())
             {
                 case "gas":
-                    ClaimTransaction tx = coins.Claim();
-                    if (tx != null)
+                    ClaimTransaction[] txs = coins.Claim();
+                    if (txs.Length > 0)
                     {
-                        Console.WriteLine($"Tranaction Suceeded: {tx.Hash}");
+                        foreach (ClaimTransaction tx in txs)
+                        {
+                            Console.WriteLine($"Tranaction Suceeded: {tx.Hash}");
+                        }
                     }
                     return true;
                 default:

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -378,7 +378,7 @@ namespace Neo.Shell
                 "\tlist key\n" +
                 "\tshow utxo [id|alias]\n" +
                 "\tshow gas\n" +
-                "\tclaim gas\n" +
+                "\tclaim gas [all]\n" +
                 "\tcreate address [n=1]\n" +
                 "\timport key <wif|path>\n" +
                 "\texport key [address] [path]\n" +

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -512,7 +512,7 @@ namespace Neo.Shell
                         {
                             case "all":
                                 ClaimTransaction[] txs = coins.ClaimAll();
-                                if (txs != null && txs.Length > 0)
+                                if (txs.Length > 0)
                                 {
                                     foreach (ClaimTransaction tx in txs)
                                     {

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -506,15 +506,33 @@ namespace Neo.Shell
             switch (args[1].ToLower())
             {
                 case "gas":
-                    ClaimTransaction[] txs = coins.Claim();
-                    if (txs.Length > 0)
+                    if (args.Length > 2)
                     {
-                        foreach (ClaimTransaction tx in txs)
+                        switch (args[2].ToLower())
+                        {
+                            case "all":
+                                ClaimTransaction[] txs = coins.ClaimAll();
+                                if (txs.Length > 0)
+                                {
+                                    foreach (ClaimTransaction tx in txs)
+                                    {
+                                        Console.WriteLine($"Tranaction Suceeded: {tx.Hash}");
+                                    }
+                                }
+                                return true;
+                            default:
+                                return base.OnCommand(args);
+                        }
+                    }
+                    else
+                    {
+                        ClaimTransaction tx = coins.Claim();
+                        if (tx != null)
                         {
                             Console.WriteLine($"Tranaction Suceeded: {tx.Hash}");
                         }
+                        return true;
                     }
-                    return true;
                 default:
                     return base.OnCommand(args);
             }


### PR DESCRIPTION
This PR modified claim gas operation to limited 50 claims per transaction. This may create more than 1 ClaimTransaction during 1 cmd but make it possible to claim gas from 10k transactions. Extra output is provided to show the progress.