### PR TITLE
Missing IP parameter

### DIFF
--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -859,7 +859,7 @@ namespace Neo.Shell
             }
             if (useRPC)
             {
-                system.StartRpc(Settings.Default.RPC.Port,
+                system.StartRpc(IPAddress.Any, Settings.Default.RPC.Port,
                     wallet: Program.Wallet,
                     sslCert: Settings.Default.RPC.SslCert,
                     password: Settings.Default.RPC.SslCertPassword);


### PR DESCRIPTION
Taken from previous working versions: IPAddress.Any parameter