### PR TITLE
Command not found message instead of error

### DIFF
--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -26,7 +26,7 @@ namespace Neo.Services
                     Console.WriteLine(Assembly.GetEntryAssembly().GetName().Version);
                     return true;
                 default:
-                    Console.WriteLine("error");
+                    Console.WriteLine("error: command not found " + args[0].ToLower());
                     return true;
             }
         }


### PR DESCRIPTION
Example:
```cs
neo> dump storage
error
neo> abcd
error: command not found abcd
neo>
```