### PR TITLE
Add support for deploying contracts + initial support for invoking contracts. Also add support for quoted arguments that may contain spaces.

### DIFF
--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Reflection;
 using System.Security;
 using System.Text;
@@ -35,6 +37,102 @@ namespace Neo.Services
         protected internal abstract void OnStart(string[] args);
 
         protected internal abstract void OnStop();
+
+        private static string[] ParseCommandLine(string line)
+        {
+            List<string> outputArgs = new List<string>();
+            using (StringReader reader = new StringReader(line))
+            {
+                while (true)
+                {
+                    switch (reader.Peek())
+                    {
+                        case -1:
+                            return outputArgs.ToArray();
+                        case ' ':
+                            reader.Read();
+                            break;
+                        case '\"':
+                            outputArgs.Add(ParseCommandLineString(reader));
+                            break;
+                        default:
+                            outputArgs.Add(ParseCommandLineArgument(reader));
+                            break;
+                    }
+                }
+            }
+        }
+
+        private static string ParseCommandLineArgument(TextReader reader)
+        {
+            StringBuilder sb = new StringBuilder();
+            while (true)
+            {
+                int c = reader.Read();
+                switch (c)
+                {
+                    case -1:
+                    case ' ':
+                        return sb.ToString();
+                    default:
+                        sb.Append((char)c);
+                        break;
+                }
+            }
+        }
+
+        private static string ParseCommandLineString(TextReader reader)
+        {
+            if (reader.Read() != '\"') throw new FormatException();
+            StringBuilder sb = new StringBuilder();
+            while (true)
+            {
+                int c = reader.Peek();
+                switch (c)
+                {
+                    case '\"':
+                        reader.Read();
+                        return sb.ToString();
+                    case '\\':
+                        sb.Append(ParseEscapeCharacter(reader));
+                        break;
+                    default:
+                        reader.Read();
+                        sb.Append((char)c);
+                        break;
+                }
+            }
+        }
+
+        private static char ParseEscapeCharacter(TextReader reader)
+        {
+            if (reader.Read() != '\\') throw new FormatException();
+            int c = reader.Read();
+            switch (c)
+            {
+                case -1:
+                    throw new FormatException();
+                case 'n':
+                    return '\n';
+                case 'r':
+                    return '\r';
+                case 't':
+                    return '\t';
+                case 'x':
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < 2; i++)
+                    {
+                        int h = reader.Read();
+                        if (h >= '0' && h <= '9' || h >= 'A' && h <= 'F' || h >= 'a' && h <= 'f')
+                            sb.Append((char)h);
+                        else
+                            throw new FormatException();
+                    }
+                    return (char)byte.Parse(sb.ToString(), NumberStyles.AllowHexSpecifier);
+                default:
+                    return (char)c;
+            }
+        }
 
         public static string ReadPassword(string prompt)
         {
@@ -121,54 +219,6 @@ namespace Neo.Services
             Console.WriteLine($"{ServiceName} Version: {ver}");
             Console.WriteLine();
 
-            // Simple handling of quoted or non quoted arguments.
-            string[] SplitArgStrings(string line)
-            {
-                bool inQuote = false;
-                List<string> outputArgs = new List<string>();
-                StringBuilder builder = new StringBuilder();
-
-                void AddArgFromBuilder()
-                {
-                    if (builder.Length > 0)
-                    {
-                        outputArgs.Add(builder.ToString());
-                        builder.Clear();
-                    }
-                }
-
-                for (int index = 0; index < line.Length; index++)
-                {
-                    char c = line[index];
-                    if (c == '\\')
-                    {
-                        if (++index >= line.Length)
-                        {
-                            break;
-                        }
-
-                        builder.Append(line[index]);
-                        continue;
-                    }
-
-                    if (!inQuote && c == ' ')
-                    {
-                        AddArgFromBuilder();
-                        continue;
-                    }
-                    if (c == '"')
-                    {
-                        inQuote = !inQuote;
-                        continue;
-                    }
-
-                    builder.Append(c);
-                }
-                AddArgFromBuilder();
-
-                return outputArgs.ToArray();
-            }
-
             while (running)
             {
                 if (ShowPrompt)
@@ -182,7 +232,7 @@ namespace Neo.Services
                 if (line == null) break;
                 Console.ForegroundColor = ConsoleColor.White;
 
-                string[] args = SplitArgStrings(line);
+                string[] args = ParseCommandLine(line);
                 if (args.Length == 0)
                     continue;
                 try

--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -125,7 +125,7 @@ namespace Neo.Services
             string[] SplitArgStrings(string line)
             {
                 bool inQuote = false;
-                List<string> outputArgs = new List<String>();
+                List<string> outputArgs = new List<string>();
                 StringBuilder builder = new StringBuilder();
 
                 void AddArgFromBuilder()

--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Security;
 using System.Text;
@@ -120,6 +121,55 @@ namespace Neo.Services
             Console.WriteLine($"{ServiceName} Version: {ver}");
             Console.WriteLine();
 
+            // Simple handling of quoted or non quoted arguments.
+            string[] SplitArgStrings(string line)
+            {
+                bool inQuote = false;
+                List<string> outputArgs = new List<String>();
+                StringBuilder builder = new StringBuilder();
+
+                void AddArgFromBuilder()
+                {
+                    string arg = builder.ToString();
+                    if (arg.Length > 0)
+                    {
+                        outputArgs.Add(arg);
+                        builder.Clear();
+                    }
+                }
+
+                for (int index = 0; index < line.Length; index++)
+                {
+                    char c = line[index];
+                    if (c == '\\')
+                    {
+                        if (++index >= line.Length)
+                        {
+                            break;
+                        }
+
+                        builder.Append(line[index]);
+                        continue;
+                    }
+
+                    if (!inQuote && c == ' ')
+                    {
+                        AddArgFromBuilder();
+                        continue;
+                    }
+                    if (c == '"')
+                    {
+                        inQuote = !inQuote;
+                        continue;
+                    }
+
+                    builder.Append(c);
+                }
+                AddArgFromBuilder();
+
+                return outputArgs.ToArray();
+            }
+
             while (running)
             {
                 if (ShowPrompt)
@@ -132,7 +182,8 @@ namespace Neo.Services
                 string line = Console.ReadLine()?.Trim();
                 if (line == null) break;
                 Console.ForegroundColor = ConsoleColor.White;
-                string[] args = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                string[] args = SplitArgStrings(line);
                 if (args.Length == 0)
                     continue;
                 try

--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Security;

--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -130,10 +130,9 @@ namespace Neo.Services
 
                 void AddArgFromBuilder()
                 {
-                    string arg = builder.ToString();
-                    if (arg.Length > 0)
+                    if (builder.Length > 0)
                     {
-                        outputArgs.Add(arg);
+                        outputArgs.Add(builder.ToString());
                         builder.Clear();
                     }
                 }

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -175,7 +175,7 @@ namespace Neo.Shell
                     if (tx.Inputs == null) tx.Inputs = new CoinReference[0];
                     if (tx.Outputs == null) tx.Outputs = new TransactionOutput[0];
                     if (tx.Witnesses == null) tx.Witnesses = new Witness[0];
-                    ApplicationEngine engine = ApplicationEngine.Run(tx.Script, tx);
+                    ApplicationEngine engine = ApplicationEngine.Run(tx.Script, tx, null, true);
                     StringBuilder sb = new StringBuilder();
                     sb.AppendLine($"VM State: {engine.State}");
                     sb.AppendLine($"Gas Consumed: {engine.GasConsumed}");

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -612,6 +612,7 @@ namespace Neo.Shell
                 "\tsign <jsonObjectToSign>\n" +
                 "Contract Commands:\n" +
                 "\tcontract deploy <avmFilePath> <paramTypes> <returnTypeHexString> <hasStorage (true|false)> <hasDynamicInvoke (true|false)> <isPayable (true|false) <contractName> <contractVersion> <contractAuthor> <contractEmail> <contractDescription>\n" +
+                "\tcontract invoke <scripthash> <command> [optionally quoted params separated by space]\n" +
 
                 "Node Commands:\n" +
                 "\tshow state\n" +
@@ -1084,6 +1085,11 @@ namespace Neo.Shell
                 }
             store = new LevelDBStore(Path.GetFullPath(Settings.Default.Paths.Chain));
             system = new NeoSystem(store);
+            // HandleStart(useRPC);
+        }
+
+        private void HandleStart(bool useRPC)
+        {
             system.StartNode(Settings.Default.P2P.Port, Settings.Default.P2P.WsPort);
             if (Settings.Default.UnlockWallet.IsActive)
             {

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -1085,7 +1085,7 @@ namespace Neo.Shell
                 }
             store = new LevelDBStore(Path.GetFullPath(Settings.Default.Paths.Chain));
             system = new NeoSystem(store);
-            // HandleStart(useRPC);
+            HandleStart(useRPC);
         }
 
         private void HandleStart(bool useRPC)

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -1,6 +1,7 @@
 ﻿using Akka.Actor;
 using Neo.Consensus;
 using Neo.IO;
+using Neo.IO.Json;
 using Neo.Ledger;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
@@ -9,6 +10,7 @@ using Neo.Persistence.LevelDB;
 using Neo.Plugins;
 using Neo.Services;
 using Neo.SmartContract;
+using Neo.VM;
 using Neo.Wallets;
 using Neo.Wallets.NEP6;
 using Neo.Wallets.SQLite;
@@ -22,8 +24,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Neo.IO.Json;
-using Neo.VM;
 using ECCurve = Neo.Cryptography.ECC.ECCurve;
 using ECPoint = Neo.Cryptography.ECC.ECPoint;
 
@@ -308,7 +308,7 @@ namespace Neo.Shell
             }
             catch (InvalidOperationException ex)
             {
-                Console.WriteLine($"Error creating contract params: {ex}" );
+                Console.WriteLine($"Error creating contract params: {ex}");
                 throw;
             }
             Program.Wallet.Sign(context);

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -1084,6 +1084,7 @@ namespace Neo.Shell
                 }
             store = new LevelDBStore(Path.GetFullPath(Settings.Default.Paths.Chain));
             system = new NeoSystem(store);
+            system.StartNode(Settings.Default.P2P.Port, Settings.Default.P2P.WsPort, Settings.Default.P2P.MinDesiredConnections, Settings.Default.P2P.MaxConnections);
             if (Settings.Default.UnlockWallet.IsActive)
             {
                 try


### PR DESCRIPTION
Linux users can't easily run neo-gui for deploying contracts, and it seems like neo-cli should support deploying and invoking contracts. This gives it the ability to deploy contracts and allows passing params surrounded in quotes so spaces can be included in cli commands.

This is copied from #180 but updated to work with the latest code base. I tested deploying a 38Kbyte contract. Worked nicely.
