### PR TITLE
allow empty console command to pass into OnCommand

### DIFF
--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -23,6 +23,8 @@ namespace Neo.Services
         {
             switch (args[0].ToLower())
             {
+                case "":
+                    return true;
                 case "clear":
                     Console.Clear();
                     return true;
@@ -30,8 +32,6 @@ namespace Neo.Services
                     return false;
                 case "version":
                     Console.WriteLine(Assembly.GetEntryAssembly().GetName().Version);
-                    return true;
-                case "":
                     return true;
                 default:
                     Console.WriteLine("error: command not found " + args[0]);
@@ -263,7 +263,7 @@ namespace Neo.Services
         private void RunConsole()
         {
             bool running = true;
-            string[] emptyarg = new string[] {""};
+            string[] emptyarg = new string[] { "" };
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
                 Console.Title = ServiceName;
             Console.OutputEncoding = Encoding.Unicode;

--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -31,6 +31,8 @@ namespace Neo.Services
                 case "version":
                     Console.WriteLine(Assembly.GetEntryAssembly().GetName().Version);
                     return true;
+                case "":
+                    return true;
                 default:
                     Console.WriteLine("error: command not found " + args[0]);
                     return true;
@@ -261,6 +263,7 @@ namespace Neo.Services
         private void RunConsole()
         {
             bool running = true;
+            string[] emptyarg = new string[] {""};
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
                 Console.Title = ServiceName;
             Console.OutputEncoding = Encoding.Unicode;
@@ -285,7 +288,7 @@ namespace Neo.Services
 
                 string[] args = ParseCommandLine(line);
                 if (args.Length == 0)
-                    continue;
+                    args = emptyarg;
                 try
                 {
                     running = OnCommand(args);


### PR DESCRIPTION
This change allows plugins to receive empty messages from the command-line, useful in a debugging scenario, where an empty line entry indicates the debugger should repeat the previous step command, or page through a disassembly dump.