### PR TITLE
Fix \"x error

### DIFF
--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -293,11 +293,12 @@ namespace Neo.Services
                 if (line == null) break;
                 Console.ForegroundColor = ConsoleColor.White;
 
-                string[] args = ParseCommandLine(line);
-                if (args.Length == 0)
-                    args = emptyarg;
                 try
                 {
+                    string[] args = ParseCommandLine(line);
+                    if (args.Length == 0)
+                        args = emptyarg;
+
                     running = OnCommand(args);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
If you write `\"x` your node will killed by a `FormatException`