### PR TITLE
Don't hardcode System.Text.Encoding.Unicode (which is UTF-16LE) as output encoding

### DIFF
--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -272,8 +272,10 @@ namespace Neo.Services
             bool running = true;
             string[] emptyarg = new string[] { "" };
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
                 Console.Title = ServiceName;
-            Console.OutputEncoding = Encoding.Unicode;
+                Console.OutputEncoding = Encoding.Unicode;
+            }
 
             Console.ForegroundColor = ConsoleColor.DarkGreen;
             Console.WriteLine($"{ServiceName} Version: {Assembly.GetEntryAssembly().GetVersion()}");

--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -272,10 +272,7 @@ namespace Neo.Services
             bool running = true;
             string[] emptyarg = new string[] { "" };
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
                 Console.Title = ServiceName;
-                Console.OutputEncoding = Encoding.Unicode;
-            }
 
             Console.ForegroundColor = ConsoleColor.DarkGreen;
             Console.WriteLine($"{ServiceName} Version: {Assembly.GetEntryAssembly().GetVersion()}");


### PR DESCRIPTION
GNU/Linux systems generally use UTF-8, not UTF-16.

Using UTF-16 may "appear" to work with ASCII characters because NULs are silently skipped by terminal emulators, but this causes problems when scripting neo-cli.

For now, I moved this configuration under Win32 condition, but I don't know what is the right thing to do with Win32. Maybe it makes sense to remove this statement altogether.