### PR TITLE
allow free tx as default on invocations

### DIFF
--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -283,7 +283,7 @@ namespace Neo.Shell
 
         public InvocationTransaction DecorateInvocationTransaction(InvocationTransaction tx)
         {
-            Fixed8 fee = Fixed8.FromDecimal(0);
+            Fixed8 fee = Fixed8.Zero;
 
             if (tx.Size > 1024)
             {

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -283,10 +283,11 @@ namespace Neo.Shell
 
         public InvocationTransaction DecorateInvocationTransaction(InvocationTransaction tx)
         {
-            Fixed8 fee = Fixed8.FromDecimal(0.001m);
+            Fixed8 fee = Fixed8.FromDecimal(0);
 
             if (tx.Size > 1024)
             {
+                fee = Fixed8.FromDecimal(0.001m);
                 fee += Fixed8.FromDecimal(tx.Size * 0.00001m);
             }
 


### PR DESCRIPTION
I think that it's not necessary that neo-cli enforces a minimum fee of 0.001 on all transactions, only on those that exceed 1024 bytes.