### PR TITLE
load config.json with enviroment.

### DIFF
--- a/neo-cli/Extensions.cs
+++ b/neo-cli/Extensions.cs
@@ -3,7 +3,10 @@ using System.Reflection;
 
 namespace Neo
 {
-    internal static class Helper
+    /// <summary>
+    /// Extension methods
+    /// </summary>
+    internal static class Extensions
     {
         internal static bool ToBool(this string input)
         {

--- a/neo-cli/Settings.cs
+++ b/neo-cli/Settings.cs
@@ -33,7 +33,7 @@ namespace Neo
             {
                 if (_default == null)
                 {
-                    UpdateDefault(new ConfigurationBuilder().AddJsonFile("config.json").Build());
+                    UpdateDefault(Helper.LoadConfig("config"));
                 }
 
                 return _default;


### PR DESCRIPTION
Follow up PR (neo-project/neo#851).
Use environment value of "NEO_NETWORK" to resolve which config.json should be loaded.
Especially for docker users.