### PR TITLE
Adjust the output format of show state command (2x)

### DIFF
--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -1161,7 +1161,7 @@ namespace Neo.Shell
                     foreach (RemoteNode node in LocalNode.Singleton.GetRemoteNodes().Take(Console.WindowHeight - 2).ToArray())
                     {
                         WriteLineWithoutFlicker(
-                            $"  ip: {node.Remote.Address.ToString().PadRight(15)}\tport: {node.Remote.Port}\tlisten: {node.ListenerPort}\theight: {node.LastBlockIndex}");
+                            $"  ip: {node.Remote.Address.ToString().PadRight(15)}\tport: {node.Remote.Port.ToString().PadRight(5)}\tlisten: {node.ListenerPort.ToString().PadRight(5)}\theight: {node.LastBlockIndex.ToString().PadRight(8)}");
                         linesWritten++;
                     }
 

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -1161,7 +1161,7 @@ namespace Neo.Shell
                     foreach (RemoteNode node in LocalNode.Singleton.GetRemoteNodes().Take(Console.WindowHeight - 2).ToArray())
                     {
                         WriteLineWithoutFlicker(
-                            $"  ip: {node.Remote.Address.ToString().PadRight(15)}\tport: {node.Remote.Port.ToString().PadRight(5)}\tlisten: {node.ListenerPort.ToString().PadRight(5)}\theight: {node.LastBlockIndex.ToString().PadRight(8)}");
+                            $"  ip: {node.Remote.Address.ToString().PadRight(15)}\tport: {node.Remote.Port.ToString().PadRight(5)}\tlisten: {node.ListenerPort.ToString().PadRight(5)}\theight: {node.LastBlockIndex}");
                         linesWritten++;
                     }
 

--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -1161,7 +1161,7 @@ namespace Neo.Shell
                     foreach (RemoteNode node in LocalNode.Singleton.GetRemoteNodes().Take(Console.WindowHeight - 2).ToArray())
                     {
                         WriteLineWithoutFlicker(
-                            $"  ip: {node.Remote.Address}\tport: {node.Remote.Port}\tlisten: {node.ListenerPort}\theight: {node.LastBlockIndex}");
+                            $"  ip: {node.Remote.Address.ToString().PadRight(15)}\tport: {node.Remote.Port}\tlisten: {node.ListenerPort}\theight: {node.LastBlockIndex}");
                         linesWritten++;
                     }
 


### PR DESCRIPTION
Before:
```
block: 0/4000000/4000000  connected: 10  unconnected: 100
  ip: 111.111.111.111	port: 22222	listen: 10333	height: 4000000
  ip: 222.222.222.222	port: 22222	listen: 10333	height: 4000000
  ip: 1.1.11.11	port: 22222	listen: 10333	height: 4000000
  ip: 333.333.333.333	port: 22222	listen: 10333	height: 4000000
```

After:
```
block: 0/4000000/4000000  connected: 10  unconnected: 100
  ip: 111.111.111.111	port: 22222	listen: 10333	height: 4000000
  ip: 222.222.222.222	port: 22222	listen: 10333	height: 4000000
  ip: 1.1.11.11     	port: 22222	listen: 10333	height: 4000000
  ip: 333.333.333.333	port: 22222	listen: 10333	height: 4000000
```