### PR TITLE
Update protocol.json to use testnet as default

### DIFF
--- a/ci/run-tests-in-docker.sh
+++ b/ci/run-tests-in-docker.sh
@@ -18,7 +18,7 @@ sleep 3
 # Test a RPX smart contract query
 JSONRPC_RES=$( curl --silent \
   --request POST \
-  --url localhost:10332/ \
+  --url localhost:20332/ \
   --header 'accept: application/json' \
   --header 'content-type: application/json' \
   --data '{

--- a/neo-cli/config.json
+++ b/neo-cli/config.json
@@ -1,15 +1,15 @@
-﻿{
+{
   "ApplicationConfiguration": {
     "Paths": {
       "Chain": "Chain_{0}"
     },
     "P2P": {
-      "Port": 10333,
-      "WsPort": 10334
+      "Port": 20333,
+      "WsPort": 20334
     },
     "RPC": {
       "BindAddress": "127.0.0.1",
-      "Port": 10332,
+      "Port": 20332,
       "SslCert": "",
       "SslCertPassword": "",
       "MaxGasInvoke": 10

--- a/neo-cli/protocol.json
+++ b/neo-cli/protocol.json
@@ -1,23 +1,23 @@
-﻿{
+{
   "ProtocolConfiguration": {
-    "Magic": 5195086,
+    "Magic": 1951352142,
     "AddressVersion": 23,
     "MillisecondsPerBlock": 15000,
     "StandbyValidators": [
-      "03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c",
-      "02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093",
-      "03b8d9d5771d8f513aa0869b9cc8d50986403b78c6da36890638c3d46a5adce04a",
-      "02ca0e27697b9c248f6f16e085fd0061e26f44da85b58ee835c110caa5ec3ba554",
-      "024c7b7fb6c310fccf1ba33b082519d82964ea93868d676662d4a59ad548df0e7d",
-      "02aaec38470f6aad0042c6e877cfd8087d2676b0f516fddd362801b9bd3936399e",
-      "02486fd15702c4490a26703112a5cc1d0923fd697a33406bd5a1c00e0013b09a70"
+      "023e9b32ea89b94d066e649b124fd50e396ee91369e8e2a6ae1b11c170d022256d",
+      "03009b7540e10f2562e5fd8fac9eaec25166a58b26e412348ff5a86927bfac22a2",
+      "02ba2c70f5996f357a43198705859fae2cfea13e1172962800772b3d588a9d4abd",
+      "03408dcd416396f64783ac587ea1e1593c57d9fea880c8a6a1920e92a259477806",
+      "02a7834be9b32e2981d157cb5bbd3acb42cfd11ea5c3b10224d7a44e98c5910f1b",
+      "0214baf0ceea3a66f17e7e1e839ea25fd8bed6cd82e6bb6e68250189065f44ff01",
+      "030205e9cefaea5a1dfc580af20c8d5aa2468bb0148f1a5e4605fc622c80e604ba"
     ],
     "SeedList": [
-      "seed1.neo.org:10333",
-      "seed2.neo.org:10333",
-      "seed3.neo.org:10333",
-      "seed4.neo.org:10333",
-      "seed5.neo.org:10333"
+      "seed1t.neo.org:20333",
+      "seed2t.neo.org:20333",
+      "seed3t.neo.org:20333",
+      "seed4t.neo.org:20333",
+      "seed5t.neo.org:20333"
     ]
   }
 }


### PR DESCRIPTION
I think it is reasonable to make testnet configuration the default for now. There is no reason to keep Neo 2 main net configuration as default because it is not compatible.